### PR TITLE
Fix `condition` example inconsistent with docs

### DIFF
--- a/src/workflows.ts
+++ b/src/workflows.ts
@@ -31,8 +31,8 @@ export async function SubscriptionWorkflow(
   // Start the free trial period. User can still cancel subscription during this time
   if (
     await wf.condition(
-      customer.Subscription.TrialPeriod,
-      () => subscriptionCancelled
+      () => subscriptionCancelled,
+      customer.Subscription.TrialPeriod
     )
   ) {
     // If customer cancelled their subscription during trial period, send notification email
@@ -58,8 +58,8 @@ export async function SubscriptionWorkflow(
       // whichever comes first
       if (
         await wf.condition(
-          customer.Subscription.BillingPeriod,
-          () => subscriptionCancelled
+          () => subscriptionCancelled,
+          customer.Subscription.BillingPeriod
         )
       ) {
         // If customer cancelled their subscription send notification email


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- Change the subscription use case TypeScript source code:
  - Change the usage of `wf.condition(timeout, fn)` to `wf.condition(fn, timeout?)`

## Why?
<!-- Tell your future self why have you made these changes -->
The usage is inconsistent with the TypeScript SDK condition docs [here](https://docs.temporal.io/docs/typescript/workflows/#condition). According to the TypeScript SDK docs, the call should be `wf.condition(fn, timeout?)` not `wf.condition(timeout, fn)`

## Checklist
3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
There may be others needed, but I came across this.